### PR TITLE
Mainly add the ability to create master ssh key if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
+rsnapshot_slave_user_password: Unencrypted_password #Use ansible vault to store it 
 rsnapshot_slave_user_shell: /bin/bash
                                 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ rsnapshot_master_host_user:  root
 rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
-rsnapshot_slave_user: backupuserrsnapshot_slave_user_shell: /bin/bash
+rsnapshot_slave_user: backupuser
+rsnapshot_slave_user_shell: /bin/bash
                                 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists
 rsnapshot_slave_manage_minimal_required_master_configuration: True

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
-rsnapshot_slave_user_password: False #If set, use an unencrypted value and store it in vault
+rsnapshot_slave_user_passwd: False #If set, use an unencrypted value and store it in vault
 rsnapshot_slave_user_shell: /bin/bash
                                 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ Minimum Ansible Version: 1.5
 
 ```yaml
 rsnapshot_master_host: False    # Must be defined
-rsnapshot_master_host_user:  "{{ ansible_ssh_user }}"
+rsnapshot_master_host_user:  root
 rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
-rsnapshot_slave_user: backupuser
+rsnapshot_slave_user: backupuserrsnapshot_slave_user_shell: /bin/bash
+                                
+# Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists
+rsnapshot_slave_manage_minimal_required_master_configuration: True
 ```
 
 ## Example (Playbook)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
-rsnapshot_slave_user_password: Unencrypted_password #Use ansible vault to store it 
+rsnapshot_slave_user_password: False #If set, use an unencrypted value and store it in vault
 rsnapshot_slave_user_shell: /bin/bash
                                 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
-rsnapshot_slave_user_passwd: False
+rsnapshot_slave_user_passwd:  ""
 rsnapshot_slave_user_shell: /bin/bash
 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ rsnapshot_master_ssh_key: id_rsa
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
 rsnapshot_slave_user_shell: /bin/bash
+
+rsnapshot_slave_manage_minimal_required_master_configuration: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host
 rsnapshot_slave_user: backupuser
+rsnapshot_slave_user_passwd: False
 rsnapshot_slave_user_shell: /bin/bash
 
 # Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,5 @@ rsnapshot_master_ssh_key: id_rsa
 rsnapshot_slave_user: backupuser
 rsnapshot_slave_user_shell: /bin/bash
 
+# Allow rsnapshot client to create master user and ssh-keygen if it doesn't exists
 rsnapshot_slave_manage_minimal_required_master_configuration: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 rsnapshot_master_host: False
-rsnapshot_master_host_user:  "{{ ansible_ssh_user }}"
+rsnapshot_master_host_user: root
 rsnapshot_master_ssh_key: id_rsa
 
 # User used by the rsnapshot master to connect on the configured host

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,7 +11,7 @@
   user:
     name: "{{ rsnapshot_slave_user }}"
     password: "{{ rsnapshot_slave_user_passwd | password_hash('sha512') }}"
-  when: rsnapshot_slave_user_passwd
+  when: rsnapshot_slave_user_passwd != ""
 
 - name: Sudo configuration for the backup system user
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,12 @@
             owner=root group=root mode=0440
   when: ansible_os_family == "Debian" and ansible_lsb.major_release|int >= 6
 
+# Ensure that the master user and ssh-key have been generated
+# On a multi-host setup this prevent issues when backup-master
+# is configured *after* a client
+- include_tasks: config_master.yml
+  when: rsnapshot_slave_manage_minimal_required_master_configuration
+
 # Put SSH relative tasks in another file to bypass the Ansible bug #15746:
 #   https://github.com/ansible/ansible/issues/15746
 # ('delegate_to' statement is evaluated before 'when')

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -10,8 +10,8 @@
 - name: Set password for backup user if provided
   user:
     name: "{{ rsnapshot_slave_user }}"
-    password: "{{ rsnapshot_slave_user_password | password_hash('sha512') }}"
-  when: rsnapshot_slave_user_password
+    password: "{{ rsnapshot_slave_user_passwd | password_hash('sha512') }}"
+  when: rsnapshot_slave_user_passwd
 
 - name: Sudo configuration for the backup system user
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,7 +11,7 @@
   user:
     name: "{{ rsnapshot_slave_user }}"
     password: "{{ rsnapshot_slave_user_password | password_hash('sha512') }}"
-  when: rsnapshot_slave_user_password is defined
+  when: rsnapshot_slave_user_password
 
 - name: Sudo configuration for the backup system user
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -4,7 +4,14 @@
   user:
     name: "{{ rsnapshot_slave_user }}"
     shell: "{{ rsnapshot_slave_user_shell }}"
-    update_password: on_create
+
+# Account with no password may be locked down
+# which prevent logging through SSH even with ssh key
+- name: Set password for backup user if provided
+  user:
+    name: "{{ rsnapshot_slave_user }}"
+    password: "{{ rsnapshot_slave_user_password | password_hash('sha512') }}"
+  when: rsnapshot_slave_user_password is defined
 
 - name: Sudo configuration for the backup system user
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,12 +1,18 @@
 ---
 
 - name: Add backup system user
-  user: name={{ rsnapshot_slave_user }} shell={{ rsnapshot_slave_user_shell }}
-        update_password=on_create
+  user:
+    name: "{{ rsnapshot_slave_user }}"
+    shell: "{{ rsnapshot_slave_user_shell }}"
+    update_password: on_create
 
 - name: Sudo configuration for the backup system user
-  template: src=sudo_backupuser dest=/etc/sudoers.d/{{ rsnapshot_slave_user }}
-            owner=root group=root mode=0440
+  template:
+    src: sudo_backupuser
+    dest: "/etc/sudoers.d/{{ rsnapshot_slave_user }}"
+    owner: root
+    group: root
+    mode: 0440
   when: ansible_os_family == "Debian" and ansible_lsb.major_release|int >= 6
 
 # Ensure that the master user and ssh-key have been generated

--- a/tasks/config_master.yml
+++ b/tasks/config_master.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Check if master host user exists
+  command: "getent passwd {{ rsnapshot_master_host_user }}"
+  register: rsnapshot_master_host_user_exists
+  delegate_to: "{{ rsnapshot_master_host }}"
+  failed_when: False
+  changed_when: False
+  check_mode: no
+
+- name: Check if master SSH key exists
+  stat:
+    path: "$HOME/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
+  delegate_to: "{{ rsnapshot_master_host }}"
+  become: yes
+  become_user: "{{ rsnapshot_master_host_user }}"
+  register: rsnapshot_master_key_exists
+
+- name: Create master SSH key and user if master host user doesn't exists
+  user:
+    name: "{{ rsnapshot_master_host_user }}"
+    generate_ssh_key: yes
+    ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
+  when: not rsnapshot_master_key_exists.stat.exists and rsnapshot_master_host_user_exists.rc != 0
+  delegate_to: "{{ rsnapshot_master_host }}"
+  become: yes
+  become_user: root
+
+- name: Create master SSH key if it doesn't exist
+  shell: ssh-keygen -b 2048 -t rsa -f $HOME/.ssh/{{ rsnapshot_master_ssh_key }} -q -N ""
+  args:
+    creates: "$HOME/.ssh/{{ rsnapshot_master_ssh_key }}"
+  when: not rsnapshot_master_key_exists.stat.exists and rsnapshot_master_host_user_exists.rc == 0
+  delegate_to: "{{ rsnapshot_master_host }}"
+  become: yes
+  become_user: "{{ rsnapshot_master_host_user }}"

--- a/tasks/config_master.yml
+++ b/tasks/config_master.yml
@@ -5,6 +5,7 @@
     name: "{{ rsnapshot_master_host_user }}"
     generate_ssh_key: yes
     ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
+    ssh_key_comment: "rsnapshot master user {{ rsnapshot_master_host_user }} at {{ rsnapshot_master_host }}"
   delegate_to: "{{ rsnapshot_master_host }}"
   become: yes
   become_user: root

--- a/tasks/config_master.yml
+++ b/tasks/config_master.yml
@@ -1,36 +1,11 @@
 ---
 
-- name: Check if master host user exists
-  command: "getent passwd {{ rsnapshot_master_host_user }}"
-  register: rsnapshot_master_host_user_exists
-  delegate_to: "{{ rsnapshot_master_host }}"
-  failed_when: False
-  changed_when: False
-  check_mode: no
-
-- name: Check if master SSH key exists
-  stat:
-    path: "$HOME/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
-  delegate_to: "{{ rsnapshot_master_host }}"
-  become: yes
-  become_user: "{{ rsnapshot_master_host_user }}"
-  register: rsnapshot_master_key_exists
-
 - name: Create master SSH key and user if master host user doesn't exists
   user:
     name: "{{ rsnapshot_master_host_user }}"
     generate_ssh_key: yes
     ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
-  when: not rsnapshot_master_key_exists.stat.exists and rsnapshot_master_host_user_exists.rc != 0
   delegate_to: "{{ rsnapshot_master_host }}"
   become: yes
   become_user: root
 
-- name: Create master SSH key if it doesn't exist
-  shell: ssh-keygen -b 2048 -t rsa -f $HOME/.ssh/{{ rsnapshot_master_ssh_key }} -q -N ""
-  args:
-    creates: "$HOME/.ssh/{{ rsnapshot_master_ssh_key }}"
-  when: not rsnapshot_master_key_exists.stat.exists and rsnapshot_master_host_user_exists.rc == 0
-  delegate_to: "{{ rsnapshot_master_host }}"
-  become: yes
-  become_user: "{{ rsnapshot_master_host_user }}"

--- a/tasks/config_ssh.yml
+++ b/tasks/config_ssh.yml
@@ -2,12 +2,9 @@
 
 - name: Retrieve the SSH public key on the rsnapshot master
   delegate_to: "{{ rsnapshot_master_host }}"
-  become: yes
-  become_user: "{{ rsnapshot_master_host_user }}"
-  command: "cat $HOME/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
+  command: "sudo -u {{ rsnapshot_master_host_user }} cat /home/{{ rsnapshot_master_host_user }}/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
   register: rsnapshot_master_ssh_pubkey
   changed_when: False
-  check_mode: no
 
 - name: Set the SSH public key for the backup system user
   authorized_key:

--- a/tasks/config_ssh.yml
+++ b/tasks/config_ssh.yml
@@ -7,7 +7,7 @@
   command: "cat $HOME/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
   register: rsnapshot_master_ssh_pubkey
   changed_when: False
-  always_run: True
+  check_mode: no
 
 - name: Set the SSH public key for the backup system user
   authorized_key:

--- a/tasks/config_ssh.yml
+++ b/tasks/config_ssh.yml
@@ -2,7 +2,8 @@
 
 - name: Retrieve the SSH public key on the rsnapshot master
   delegate_to: "{{ rsnapshot_master_host }}"
-  remote_user: "{{ rsnapshot_master_host_user }}"
+  become: yes
+  become_user: "{{ rsnapshot_master_host_user }}"
   command: "cat $HOME/.ssh/{{ rsnapshot_master_ssh_key }}.pub"
   register: rsnapshot_master_ssh_pubkey
   changed_when: False

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 
 - name: Install required packages
   apt:  pkg=rsync,sudo
-        state=installed
+        state=present
         update_cache=yes
 
 - name: Install the 'rsync-wrapper.sh' script, called by the master

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,8 +5,8 @@
     pkg:
       - rsync
       - sudo
-  state: present
-  update_cache: yes
+    state: present
+    update_cache: yes
 
 - name: Install the 'rsync-wrapper.sh' script, called by the master
   copy:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,17 @@
 ---
 
 - name: Install required packages
-  apt:  pkg=rsync,sudo
-        state=present
-        update_cache=yes
+  apt:
+    pkg:
+      - rsync
+      - sudo
+  state: present
+  update_cache: yes
 
 - name: Install the 'rsync-wrapper.sh' script, called by the master
-  copy: src=rsync-wrapper.sh dest=/usr/local/bin/rsync-wrapper.sh
-        owner=root group=root mode=0755
+  copy:
+    src: rsync-wrapper.sh
+    dest: /usr/local/bin/rsync-wrapper.sh
+    owner: root
+    group: root
+    mode: 0755


### PR DESCRIPTION
When provisioning inventories with master and slave, the slave roles fails if the master role hasn't been run on the master server because the ssh-key doesn't exist yet.

This PR introduces the (configurable) ability to create the missing ssh-key on the master if they don't exist.

It fixes also some deprecation warning and use YAML syntax everywhere.